### PR TITLE
feat: better cc toolchain config

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -71,8 +71,6 @@ def _winlibs_mingw_impl(rctx):
         "%{compiler_package}": compiler_package,
         "%{compiler_package_path}": compiler_package_path,
         
-        "%{target_name}": rctx.attr.target_name,
-        "%{target_cpu}": rctx.attr.target_cpu,
         "%{exec_compatible_with}": json.encode(rctx.attr.exec_compatible_with),
         "%{target_compatible_with}": json.encode(rctx.attr.target_compatible_with),
         
@@ -83,8 +81,7 @@ def _winlibs_mingw_impl(rctx):
         "%{defines}": json.encode(rctx.attr.defines),
         "%{includedirs}": json.encode(rctx.attr.includedirs),
         "%{linkdirs}": json.encode(rctx.attr.linkdirs),
-
-        "%{flags_packed}": json.encode(rctx.attr.flags_packed),
+        "%{toolchain_libs}": json.encode(rctx.attr.toolchain_libs),
     }
     rctx.template(
         "BUILD",
@@ -130,8 +127,7 @@ _winlibs_mingw_toolchain = repository_rule(
         'defines': attr.string_list(default = []),
         'includedirs': attr.string_list(default = []),
         'linkdirs': attr.string_list(default = []),
-
-        'flags_packed': attr.string_dict(default = {}),
+        'toolchain_libs': attr.string_list(default = []),
     },
     local = False,
     implementation = _winlibs_mingw_impl,
@@ -153,8 +149,7 @@ def winlibs_mingw_toolchain(
         defines = [],
         includedirs = [],
         linkdirs = [],
-        
-        flags_packed = {},
+        toolchain_libs = [],
         
         local_download = True,
         registry = WINLIBS_MINGW_REGISTRY,
@@ -181,9 +176,8 @@ def winlibs_mingw_toolchain(
         defines: defines
         includedirs: includedirs
         linkdirs: linkdirs
+        toolchain_libs: toolchain_libs
         
-        flags_packed: pack of flags, checkout the syntax at bazel_utilities
-
         local_download: wether the archive should be downloaded in the same repository (True) or in its own repo
         registry: The arm registry to use, to allow close environement to provide their own mirroir/url
 
@@ -226,8 +220,7 @@ def winlibs_mingw_toolchain(
         defines = defines,
         includedirs = includedirs,
         linkdirs = linkdirs,
-
-        flags_packed = flags_packed,
+        toolchain_libs = toolchain_libs,
     )
 
     if auto_register_toolchain:

--- a/templates/BUILD_clang.compiler.tpl
+++ b/templates/BUILD_clang.compiler.tpl
@@ -7,15 +7,34 @@ filegroup(
     name = "cpp",
     srcs = ["bin/clang-cpp%{extention}"],
 )
-
 filegroup(
     name = "cc",
     srcs = ["bin/clang%{extention}"],
 )
-
 filegroup(
     name = "cxx",
     srcs = ["bin/clang++%{extention}"],
+)
+filegroup(
+    name = "as",
+    srcs = ["bin/llvm-as%{extention}"],
+)
+filegroup(
+    name = "ar",
+    srcs = ["bin/llvm-ar%{extention}"],
+)
+filegroup(
+    name = "ld",
+    srcs = ["bin/lld%{extention}"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/llvm-objcopy%{extention}"],
+)
+filegroup(
+    name = "strip",
+    srcs = ["bin/llvm-strip%{extention}"],
 )
 
 filegroup(
@@ -24,53 +43,30 @@ filegroup(
 )
 
 filegroup(
-    name = "ar",
-    srcs = ["bin/llvm-ar%{extention}"],
+    name = "size",
+    srcs = ["bin/llvm-size%{extention}"],
 )
-
-filegroup(
-    name = "ld",
-    srcs = ["bin/lld%{extention}"],
-)
-
 filegroup(
     name = "nm",
     srcs = ["bin/llvm-nm%{extention}"],
 )
-
-filegroup(
-    name = "objcopy",
-    srcs = ["bin/llvm-objcopy%{extention}"],
-)
-
 filegroup(
     name = "objdump",
     srcs = ["bin/llvm-objdump%{extention}"],
 )
-
-filegroup(
-    name = "strip",
-    srcs = ["bin/llvm-strip%{extention}"],
-)
-
-filegroup(
-    name = "as",
-    srcs = ["bin/llvm-as%{extention}"],
-)
-
-filegroup(
-    name = "size",
-    srcs = ["bin/llvm-size%{extention}"],
-)
-
 filegroup(
     name = "dwp",
     srcs = ["bin/llvm-dwp%{extention}"],
 )
 
+filegroup(
+    name = "dbg",
+    srcs = ["bin/lldb%{extention}"],
+)
+
 
 filegroup(
-    name = "compiler_includes",
+    name = "toolchain_includes",
     srcs = glob([
         "lib/clang/%{clang_version}/include/**",
         "x86_64-w64-mingw32/include/**",
@@ -79,7 +75,7 @@ filegroup(
 )
 
 filegroup(
-    name = "compiler_libs",
+    name = "toolchain_libs",
     srcs = glob([
         "x86_64-w64-mingw32/lib/*",
         "lib/*",
@@ -87,25 +83,27 @@ filegroup(
 )
 
 filegroup(
-    name = "toolchains_bins",
+    name = "toolchain_bins",
     srcs = glob([
         "x86_64-w64-mingw32/bin/*%{extention}",
         "bin/*%{extention}",
     ]),
 )
 
+
 filegroup(
-    name = "compiler_pieces",
+    name = "all_files",
     srcs = [
-        ":compiler_includes",
-        ":compiler_libs",
+        ":toolchain_includes",
+        ":toolchain_libs",
+        ":toolchain_bins",
     ],
 )
 
 filegroup(
     name = "compiler_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
         ":cpp",
         ":cc",
         ":cxx",
@@ -115,7 +113,7 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
         ":ld",
@@ -126,11 +124,12 @@ filegroup(
 filegroup(
     name = "coverage_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
-        ":cov",
         ":ld",
+        ":cov",
     ],
 )
 
@@ -140,28 +139,20 @@ filegroup(
         ":cpp",
         ":cc",
         ":cxx",
-        ":cov",
         ":ar",
         ":ld",
-        ":nm",
+
         ":objcopy",
-        ":objdump",
         ":strip",
+
+        ":cov",
+
+        ":nm",
+        ":objdump",
         ":as",
         ":size",
         ":dwp",
-    ],
-)
-
-
-filegroup(
-    name = "dbg",
-    srcs = ["bin/lldb%{extention}"],
-)
-
-filegroup(
-    name = "compiler_extras",
-    srcs = [
-        "dbg",
+        
+        ":dbg",
     ],
 )

--- a/templates/BUILD_clang.tpl
+++ b/templates/BUILD_clang.tpl
@@ -1,39 +1,36 @@
 ""
 
-load("@bazel_winlibs_mingw//:artifacts_patterns.bzl", "MINGW_ATTIFACTS_PATTERNS")
 load("@bazel_utilities//toolchains:cc_toolchain_config.bzl", "cc_toolchain_config")
+load("@bazel_winlibs_mingw//:artifacts_patterns.bzl", "MINGW_ATTIFACTS_PATTERNS")
 
 package(default_visibility = ["//visibility:public"])
 
 cc_toolchain_config(
     name = "cc_toolchain_config_%{toolchain_id}",
     toolchain_identifier = "%{toolchain_id}",
-    host_name = "%{host_name}",
-    target_name = "%{target_name}",
-    target_cpu = "%{target_cpu}",
-    compiler = {
-        "name": "clang",
-        "cc": "clang",
-        "cxx": "clang++",
-        "cov": "llvm-cov",
-        "ar": "llvm-ar",
-        "strip": "llvm-strip",
-        "size": "llvm-size",
-        "nm": "llvm-nm",
-        "as": "llvm-as",
-        "objcopy": "llvm-objcopy",
-        "objdump": "llvm-objdump",
-        "ar": "llvm-ar",
-        "strip": "llvm-strip",
-        "size": "llvm-size",
-        "nm": "llvm-nm",
-        "as": "llvm-as",
-        "objcopy": "llvm-objcopy",
-        "objdump": "llvm-objdump",
+
+    compiler_type = "clang",
+
+    toolchain_bins = {
+        "%{compiler_package}:cpp": "cpp",
+        "%{compiler_package}:cc": "cc",
+        "%{compiler_package}:cxx": "cxx",
+        "%{compiler_package}:as": "as",
+        "%{compiler_package}:ar": "ar",
+        "%{compiler_package}:ld": "ld",
+
+        "%{compiler_package}:objcopy": "objcopy",
+        "%{compiler_package}:strip": "strip",
+
+        "%{compiler_package}:cov": "cov",
+
+        "%{compiler_package}:size": "size",
+        "%{compiler_package}:nm": "nm",
+        "%{compiler_package}:objdump": "objdump",
+        "%{compiler_package}:dwp": "dwp",
+        "%{compiler_package}:dbg": "dbg",
     },
-    toolchain_bins = "%{compiler_package}:compiler_components",
-    artifacts_patterns_packed = MINGW_ATTIFACTS_PATTERNS["%{host_name}"],
-    flags = %{flags_packed},
+
     cxx_builtin_include_directories = [
         "%{compiler_package_path}include",
         "%{compiler_package_path}x86_64-w64-mingw32/include",
@@ -50,9 +47,9 @@ cc_toolchain_config(
         "%{compiler_package_path}x86_64-w64-mingw32/lib",
     ] + %{linkdirs},
     
-    toolchain_libs = [
-        "pthread"
-    ],
+    toolchain_libs = %{toolchain_libs},
+
+    artifacts_patterns_packed = MINGW_ATTIFACTS_PATTERNS["%{host_name}"],
 )
 
 cc_toolchain(
@@ -60,16 +57,22 @@ cc_toolchain(
     toolchain_identifier = "%{toolchain_id}",
     toolchain_config = ":cc_toolchain_config_%{toolchain_id}",
     
-    all_files = "%{compiler_package}:compiler_pieces",
+    all_files = "%{compiler_package}:all_files",
     compiler_files = "%{compiler_package}:compiler_files",
     linker_files = "%{compiler_package}:linker_files",
     ar_files = "%{compiler_package}:ar",
     as_files = "%{compiler_package}:as",
+    
     objcopy_files = "%{compiler_package}:objcopy",
     strip_files = "%{compiler_package}:strip",
-    dwp_files = "%{compiler_package}:dwp",
+    
     coverage_files = "%{compiler_package}:coverage_files",
-    supports_param_files = 0
+    
+    dwp_files = "%{compiler_package}:dwp",
+
+    # dynamic_runtime_lib
+    # static_runtime_lib
+    # supports_param_files
 )
 
 toolchain(
@@ -86,15 +89,34 @@ filegroup(
     name = "cpp",
     srcs = ["bin/clang-cpp%{extention}"],
 )
-
 filegroup(
     name = "cc",
     srcs = ["bin/clang%{extention}"],
 )
-
 filegroup(
     name = "cxx",
     srcs = ["bin/clang++%{extention}"],
+)
+filegroup(
+    name = "as",
+    srcs = ["bin/llvm-as%{extention}"],
+)
+filegroup(
+    name = "ar",
+    srcs = ["bin/llvm-ar%{extention}"],
+)
+filegroup(
+    name = "ld",
+    srcs = ["bin/lld%{extention}"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/llvm-objcopy%{extention}"],
+)
+filegroup(
+    name = "strip",
+    srcs = ["bin/llvm-strip%{extention}"],
 )
 
 filegroup(
@@ -103,53 +125,30 @@ filegroup(
 )
 
 filegroup(
-    name = "ar",
-    srcs = ["bin/llvm-ar%{extention}"],
+    name = "size",
+    srcs = ["bin/llvm-size%{extention}"],
 )
-
-filegroup(
-    name = "ld",
-    srcs = ["bin/lld%{extention}"],
-)
-
 filegroup(
     name = "nm",
     srcs = ["bin/llvm-nm%{extention}"],
 )
-
-filegroup(
-    name = "objcopy",
-    srcs = ["bin/llvm-objcopy%{extention}"],
-)
-
 filegroup(
     name = "objdump",
     srcs = ["bin/llvm-objdump%{extention}"],
 )
-
-filegroup(
-    name = "strip",
-    srcs = ["bin/llvm-strip%{extention}"],
-)
-
-filegroup(
-    name = "as",
-    srcs = ["bin/llvm-as%{extention}"],
-)
-
-filegroup(
-    name = "size",
-    srcs = ["bin/llvm-size%{extention}"],
-)
-
 filegroup(
     name = "dwp",
     srcs = ["bin/llvm-dwp%{extention}"],
 )
 
+filegroup(
+    name = "dbg",
+    srcs = ["bin/lldb%{extention}"],
+)
+
 
 filegroup(
-    name = "compiler_includes",
+    name = "toolchain_includes",
     srcs = glob([
         "lib/clang/%{clang_version}/include/**",
         "x86_64-w64-mingw32/include/**",
@@ -158,7 +157,7 @@ filegroup(
 )
 
 filegroup(
-    name = "compiler_libs",
+    name = "toolchain_libs",
     srcs = glob([
         "x86_64-w64-mingw32/lib/*",
         "lib/*",
@@ -166,25 +165,27 @@ filegroup(
 )
 
 filegroup(
-    name = "toolchains_bins",
+    name = "toolchain_bins",
     srcs = glob([
         "x86_64-w64-mingw32/bin/*%{extention}",
         "bin/*%{extention}",
     ]),
 )
 
+
 filegroup(
-    name = "compiler_pieces",
+    name = "all_files",
     srcs = [
-        ":compiler_includes",
-        ":compiler_libs",
+        ":toolchain_includes",
+        ":toolchain_libs",
+        ":toolchain_bins",
     ],
 )
 
 filegroup(
     name = "compiler_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
         ":cpp",
         ":cc",
         ":cxx",
@@ -194,7 +195,7 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
         ":ld",
@@ -205,11 +206,12 @@ filegroup(
 filegroup(
     name = "coverage_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
-        ":cov",
         ":ld",
+        ":cov",
     ],
 )
 
@@ -219,29 +221,20 @@ filegroup(
         ":cpp",
         ":cc",
         ":cxx",
-        ":cov",
         ":ar",
         ":ld",
-        ":nm",
+
         ":objcopy",
-        ":objdump",
         ":strip",
+
+        ":cov",
+
+        ":nm",
+        ":objdump",
         ":as",
         ":size",
         ":dwp",
-    ],
-)
-
-
-filegroup(
-    name = "dbg",
-    srcs = ["bin/lldb%{extention}"],
-    srcs = ["bin/lldb%{extention}"],
-)
-
-filegroup(
-    name = "compiler_extras",
-    srcs = [
-        "dbg",
+        
+        ":dbg",
     ],
 )

--- a/templates/BUILD_gcc.compiler.tpl
+++ b/templates/BUILD_gcc.compiler.tpl
@@ -7,15 +7,34 @@ filegroup(
     name = "cpp",
     srcs = ["bin/cpp%{extention}"],
 )
-
 filegroup(
     name = "cc",
     srcs = ["bin/gcc%{extention}"],
 )
-
 filegroup(
     name = "cxx",
     srcs = ["bin/g++%{extention}"],
+)
+filegroup(
+    name = "as",
+    srcs = ["bin/as%{extention}"],
+)
+filegroup(
+    name = "ar",
+    srcs = ["bin/ar%{extention}"],
+)
+filegroup(
+    name = "ld",
+    srcs = ["bin/ld%{extention}"],
+)
+
+filegroup(
+    name = "objcopy",
+    srcs = ["bin/objcopy%{extention}"],
+)
+filegroup(
+    name = "strip",
+    srcs = ["bin/strip%{extention}"],
 )
 
 filegroup(
@@ -24,53 +43,30 @@ filegroup(
 )
 
 filegroup(
-    name = "ar",
-    srcs = ["bin/ar%{extention}"],
+    name = "size",
+    srcs = ["bin/size%{extention}"],
 )
-
-filegroup(
-    name = "ld",
-    srcs = ["bin/ld%{extention}"],
-)
-
 filegroup(
     name = "nm",
     srcs = ["bin/nm%{extention}"],
 )
-
-filegroup(
-    name = "objcopy",
-    srcs = ["bin/objcopy%{extention}"],
-)
-
 filegroup(
     name = "objdump",
     srcs = ["bin/objdump%{extention}"],
 )
-
-filegroup(
-    name = "strip",
-    srcs = ["bin/strip%{extention}"],
-)
-
-filegroup(
-    name = "as",
-    srcs = ["bin/as%{extention}"],
-)
-
-filegroup(
-    name = "size",
-    srcs = ["bin/size%{extention}"],
-)
-
 filegroup(
     name = "dwp",
-    srcs = [],
+    srcs = ["bin/dwp%{extention}"],
+)
+
+filegroup(
+    name = "dbg",
+    srcs = ["bin/gdb%{extention}"],
 )
 
 
 filegroup(
-    name = "compiler_includes",
+    name = "toolchain_includes",
     srcs = glob([
         "lib/gcc/x86_64-w64-mingw32/%{gcc_version}/include/**",
         "lib/gcc/x86_64-w64-mingw32/%{gcc_version}/include-fixed/**",
@@ -80,7 +76,7 @@ filegroup(
 )
 
 filegroup(
-    name = "compiler_libs",
+    name = "toolchain_libs",
     srcs = glob([
         "lib/gcc/x86_64-w64-mingw32/%{gcc_version}/*",
         "x86_64-w64-mingw32/lib/*",
@@ -89,25 +85,27 @@ filegroup(
 )
 
 filegroup(
-    name = "toolchains_bins",
+    name = "toolchain_bins",
     srcs = glob([
         "x86_64-w64-mingw32/bin/*%{extention}",
         "bin/*%{extention}",
     ]),
 )
 
+
 filegroup(
-    name = "compiler_pieces",
+    name = "all_files",
     srcs = [
-        ":compiler_includes",
-        ":compiler_libs",
+        ":toolchain_includes",
+        ":toolchain_libs",
+        ":toolchain_bins",
     ],
 )
 
 filegroup(
     name = "compiler_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
         ":cpp",
         ":cc",
         ":cxx",
@@ -117,7 +115,7 @@ filegroup(
 filegroup(
     name = "linker_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
         ":ld",
@@ -128,11 +126,12 @@ filegroup(
 filegroup(
     name = "coverage_files",
     srcs = [
-        ":compiler_pieces",
+        ":toolchain_includes",
+        ":toolchain_libs",
         ":cc",
         ":cxx",
-        ":cov",
         ":ld",
+        ":cov",
     ],
 )
 
@@ -142,28 +141,20 @@ filegroup(
         ":cpp",
         ":cc",
         ":cxx",
-        ":cov",
         ":ar",
         ":ld",
-        ":nm",
+
         ":objcopy",
-        ":objdump",
         ":strip",
+
+        ":cov",
+
+        ":nm",
+        ":objdump",
         ":as",
         ":size",
         ":dwp",
-    ],
-)
-
-
-filegroup(
-    name = "dbg",
-    srcs = ["bin/gdb%{extention}"],
-)
-
-filegroup(
-    name = "compiler_extras",
-    srcs = [
-        "dbg",
+        
+        ":dbg",
     ],
 )


### PR DESCRIPTION
Better toolchain config:
  - Enable 'no_legacy_feature' for clean feature tree; Add 'gcc' toolchain's features
  - Use of a dict instead of randomly picking binaries from a filegroup.